### PR TITLE
pattern config break test cases

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -116,6 +116,7 @@ PatternlabToNode.prototype.init_ = function() {
     this.config_.excludePatterns.forEach((pattern, index) => {
       this.config_.excludePatterns[index] = new RegExp(pattern);
     });
+
     // transform all strings in excludeStates config to regular expressions
     this.config_.excludeStates.forEach((pattern, index) => {
       this.config_.excludeStates[index] = new RegExp(pattern);
@@ -355,7 +356,9 @@ PatternlabToNode.prototype.getPatternsConfiguration = function() {
         for (var patternId in oldPatternConfig.patterns) {
           /* istanbul ignore else */
           if (oldPatternConfig.patterns.hasOwnProperty(patternId)) {
-            newPatterns[patternId] = oldPatternConfig.patterns[patternId];
+            newPatterns[patternId] = extend(
+              newPatterns[patternId],
+              oldPatternConfig.patterns[patternId]);
           }
         }
       })

--- a/test/main.js
+++ b/test/main.js
@@ -629,13 +629,9 @@ describe('main - ', () => {
       'patternConfigFile.json': {
         "patterns": {
           "pattern-1": {
-            id: "pattern-1",
-            name: "Pattern Name 1",
             data: randomInfo
           },
           "pattern-2": {
-            id: "pattern-2",
-            name: "Pattern Name 2",
             data: randomInfo2
           }
         }
@@ -762,8 +758,6 @@ describe('main - ', () => {
       "screenSizes": {},
       "patterns": {
         "pattern-1": {
-          id: "pattern-1", //TODO: remove
-          name: "Pattern Name 1", //TODO: remove
           data: randomInfo
         }
       }
@@ -815,12 +809,9 @@ describe('main - ', () => {
       },
       "patterns": {
         "pattern-1" :{
-          id: "pattern-1",
-          name: "Pattern Name 1",
           screenSizes: ['desktop']
         },
         "pattern-2": {
-          id: "pattern-2",
           name: "Pattern Name 2"
         }
       }
@@ -876,12 +867,8 @@ describe('main - ', () => {
       },
       "patterns": {
         "pattern-1" :{
-          id: "pattern-1",
-          name: "Pattern Name 1"
         },
         "pattern-2": {
-          id: "pattern-2",
-          name: "Pattern Name 2",
           additionalScreenSizes: ['additionalSize']
         }
       }
@@ -933,12 +920,8 @@ describe('main - ', () => {
       },
       "patterns": {
         "pattern-1" :{
-          id: "pattern-1",
-          name: "Pattern Name 1"
         },
         "pattern-2": {
-          id: "pattern-2",
-          name: "Pattern Name 2",
           excludeScreenSizes: ['tablet']
         }
       }
@@ -990,8 +973,6 @@ describe('main - ', () => {
       },
       "patterns": {
         "pattern-2": {
-          id: "pattern-2", // TODO: remove
-          name: "Pattern Name 2", // TODO: remove
           excludeScreenSizes: ['desktop', 'tablet']
         }
       }
@@ -1031,8 +1012,6 @@ describe('main - ', () => {
       },
       "patterns": {
         "pattern-2": {
-          id: "pattern-2", // TODO: remove
-          name: "Pattern Name 2", // TODO: remove
           screenSizes: []
         }
       }

--- a/test/patternlab-to-geminiConfigs/missingPatternScreenSizes.json
+++ b/test/patternlab-to-geminiConfigs/missingPatternScreenSizes.json
@@ -7,13 +7,9 @@
   },
   "patterns": {
     "pattern-1": {
-      "id": "pattern-no-more",
-      "name": "Pattern which is no longer part of the styleguide",
       "screenSizes": ["unknownSize_1", "unknownSize_2"]
     },
     "pattern-2": {
-      "id": "pattern-no-more",
-      "name": "Pattern which is no longer part of the styleguide",
       "additionalScreenSizes": ["unknownSize_3", "unknownSize_4"],
       "excludeScreenSizes": ["unknownSize_5", "unknownSize_6"]
     }

--- a/test/patternlab-to-geminiConfigs/patternWithModifiedAndOverwrittenScreenSizes.json
+++ b/test/patternlab-to-geminiConfigs/patternWithModifiedAndOverwrittenScreenSizes.json
@@ -11,14 +11,10 @@
   },
   "patterns": {
     "pattern-1": {
-      "id": "pattern-no-more",
-      "name": "Pattern which is no longer part of the styleguide",
       "screenSizes": ["desktop"],
       "additionalScreenSizes": ["tablet"]
     },
     "pattern-2": {
-      "id": "pattern-no-more",
-      "name": "Pattern which is no longer part of the styleguide",
       "screenSizes": ["desktop"],
       "excludeScreenSizes": ["tablet"]
     }


### PR DESCRIPTION
When pattern configs are defined, for example to overwrite the screens the genereted test cases have no name