### PR TITLE
fix(template): removed html escaping from action.steps

### DIFF
--- a/templates/main.ejs
+++ b/templates/main.ejs
@@ -19,7 +19,7 @@ gemini.suite('Patternlab - ', function(patternlabSuite) {
         .setCaptureElements(['#<%= pattern.id %> .sg-pattern-example'])<% pattern.sizes.forEach(function(size) { %>
         .capture('<%= size.name %>', function(actions, find) {
           actions.setWindowSize(<%= size.width %>, <%= size.height %>)
-            <%= action.steps %>;
+            <%- action.steps %>;
         })<% }); %>;
   });
 <% }); %>

--- a/test/expectedTestFiles/generateTestsMultiplePatternActions.js
+++ b/test/expectedTestFiles/generateTestsMultiplePatternActions.js
@@ -37,6 +37,19 @@ gemini.suite('Patternlab - ', function(patternlabSuite) {
   });
 
 
+  gemini.suite('Pattern Name 1 --- sendKeys', function(suite) {
+    suite
+        .before(function(actions, find) {
+          this.element = find('#pattern-1 .sg-pattern-example > *')
+        })
+        .setCaptureElements(['#pattern-1 .sg-pattern-example'])
+        .capture('desktop', function(actions, find) {
+          actions.setWindowSize(1440, 900)
+            .sendKeys(this.element, 'inputString');
+        });
+  });
+
+
   gemini.suite('Pattern Name 2', function(suite) {
     suite
         .setCaptureElements(['#pattern-2 .sg-pattern-example'])

--- a/test/main.js
+++ b/test/main.js
@@ -504,6 +504,12 @@ describe('main - ', () => {
                   "name": "focused",
                   "selector": "> *",
                   "steps": ".focus(this.element)"
+                },
+                {
+                  "action": "sendKeys",
+                  "name": "sendKeys",
+                  "selector": "> *",
+                  "steps": ".sendKeys(this.element, 'inputString')"
                 }
               ]
             },

--- a/test/patternlab-to-geminiConfigs/definedMultiplePatternActions.json
+++ b/test/patternlab-to-geminiConfigs/definedMultiplePatternActions.json
@@ -16,6 +16,11 @@
         {
           "action": "focus",
           "name": "focused"
+        },
+        {
+          "action": "sendKeys",
+          "name": "sendKeys",
+          "keys": "inputString"
         }
       ]
     }


### PR DESCRIPTION
The sendKeys functionality has quotes within the steps, therefore the action.steps can't be escaped